### PR TITLE
Move writer into session state to ensure it's only set in the correct states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "hotfix"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "async-trait",
  "fefix",

--- a/hotfix/Cargo.toml
+++ b/hotfix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotfix"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["David Steiner <david_j_steiner@yahoo.co.nz>"]
 edition = "2021"
 license = "MIT"

--- a/hotfix/src/session/state.rs
+++ b/hotfix/src/session/state.rs
@@ -1,5 +1,9 @@
+use crate::actors::socket_writer::WriterRef;
+use crate::message::parser::RawFixMessage;
+use tracing::{debug, error};
+
 pub enum SessionState {
-    Connected,
+    Connected { writer: WriterRef },
     LoggedOut { reconnect: bool },
     Disconnected { reconnect: bool, reason: String },
 }
@@ -9,6 +13,20 @@ impl SessionState {
         match self {
             SessionState::Disconnected { reconnect, .. } => *reconnect,
             _ => true,
+        }
+    }
+
+    pub async fn send_message(&self, message: RawFixMessage) {
+        match self {
+            Self::Connected { writer } => writer.send_raw_message(message).await,
+            _ => error!("trying to write without an established connection"),
+        }
+    }
+
+    pub async fn disconnect(&self) {
+        match self {
+            Self::Connected { writer } => writer.disconnect().await,
+            _ => debug!("disconnecting an already disconnected session"),
         }
     }
 }


### PR DESCRIPTION
This ensures consistency between the writer being set and the state machine.