### PR TITLE
Implement message integrity checks in parser

### DIFF
--- a/crates/hotfix-message/build.rs
+++ b/crates/hotfix-message/build.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+
 use hotfix_codegen as codegen;
 use hotfix_dictionary::Dictionary;
 use std::env::var;

--- a/crates/hotfix-message/src/encoder.rs
+++ b/crates/hotfix-message/src/encoder.rs
@@ -79,9 +79,11 @@ mod tests {
         let raw_message = msg.encode(&config)?;
 
         let dict = Dictionary::fix44();
-        let parsed_message = Message::from_bytes(&config, &dict, &raw_message)?;
+        let parsed_message = Message::from_bytes(&config, &dict, &raw_message)
+            .into_message()
+            .unwrap();
 
-        let symbol: &str = parsed_message.get(fix44::SYMBOL).unwrap();
+        let symbol: &str = parsed_message.get(fix44::SYMBOL)?;
         assert_eq!(symbol, "AAPL");
 
         let qty: u32 = parsed_message.get(fix44::ORDER_QTY).unwrap();
@@ -150,7 +152,9 @@ mod tests {
         let raw_message = msg.encode(&config)?;
 
         let dict = Dictionary::fix44();
-        let parsed_message = Message::from_bytes(&config, &dict, &raw_message)?;
+        let parsed_message = Message::from_bytes(&config, &dict, &raw_message)
+            .into_message()
+            .unwrap();
 
         let party_a = parsed_message
             .get_group(fix44::NO_PARTY_I_DS, 0)

--- a/crates/hotfix-message/src/error.rs
+++ b/crates/hotfix-message/src/error.rs
@@ -24,3 +24,27 @@ pub enum ParserError {
 }
 
 pub type ParserResult<T> = Result<T, ParserError>;
+
+#[derive(Error, Debug)]
+pub(crate) enum HeaderParsingError {
+    #[error("Invalid BeginString")]
+    InvalidBeginString,
+    #[error("Invalid BodyLength")]
+    InvalidBodyLength,
+    #[error("Invalid MsgType")]
+    InvalidMsgType,
+    #[error("Message ended before reaching body")]
+    IncompleteMessage,
+}
+
+pub(crate) type HeaderParsingResult<T> = Result<T, HeaderParsingError>;
+
+#[derive(Error, Debug)]
+pub(crate) enum TrailerParsingError {
+    #[error("Invalid CheckSum")]
+    InvalidCheckSum,
+    #[error("Invalid field")]
+    InvalidField(u32),
+}
+
+pub(crate) type TrailerParsingResult<T> = Result<T, TrailerParsingError>;

--- a/crates/hotfix-message/src/error.rs
+++ b/crates/hotfix-message/src/error.rs
@@ -26,25 +26,14 @@ pub enum ParserError {
 pub type ParserResult<T> = Result<T, ParserError>;
 
 #[derive(Error, Debug)]
-pub(crate) enum HeaderParsingError {
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum MessageIntegrityError {
     #[error("Invalid BeginString")]
     InvalidBeginString,
     #[error("Invalid BodyLength")]
     InvalidBodyLength,
     #[error("Invalid MsgType")]
     InvalidMsgType,
-    #[error("Message ended before reaching body")]
-    IncompleteMessage,
-}
-
-pub(crate) type HeaderParsingResult<T> = Result<T, HeaderParsingError>;
-
-#[derive(Error, Debug)]
-pub(crate) enum TrailerParsingError {
     #[error("Invalid CheckSum")]
     InvalidCheckSum,
-    #[error("Invalid field")]
-    InvalidField(u32),
 }
-
-pub(crate) type TrailerParsingResult<T> = Result<T, TrailerParsingError>;

--- a/crates/hotfix-message/src/lib.rs
+++ b/crates/hotfix-message/src/lib.rs
@@ -3,8 +3,10 @@ mod encoding;
 pub mod error;
 mod field_map;
 pub mod message;
+mod parsed_message;
 mod parser;
 pub(crate) mod parts;
+mod tags;
 
 use encoding::Buffer;
 pub use encoding::HardCodedFixFieldDefinition;

--- a/crates/hotfix-message/src/lib.rs
+++ b/crates/hotfix-message/src/lib.rs
@@ -3,7 +3,7 @@ mod encoding;
 pub mod error;
 mod field_map;
 pub mod message;
-mod parsed_message;
+pub mod parsed_message;
 mod parser;
 pub(crate) mod parts;
 mod tags;

--- a/crates/hotfix-message/src/message.rs
+++ b/crates/hotfix-message/src/message.rs
@@ -2,8 +2,9 @@ use std::io::Write;
 
 use crate::FieldType;
 use crate::encoder::Encode;
-use crate::error::{EncodingResult, ParserResult};
+use crate::error::EncodingResult;
 use crate::field_map::{Field, FieldMap};
+use crate::parsed_message::ParsedMessage;
 use crate::parser::{MessageParser, SOH};
 use crate::parts::{Body, Header, Part, RepeatingGroup, Trailer};
 use crate::{HardCodedFixFieldDefinition, fix44};
@@ -28,10 +29,20 @@ impl Message {
         msg
     }
 
-    pub fn from_bytes(config: &Config, dict: &Dictionary, data: &[u8]) -> ParserResult<Self> {
-        let mut builder = MessageParser::new(dict, config, data)?;
+    pub(crate) fn with_header(header: Header) -> Self {
+        Self {
+            header,
+            body: Body::default(),
+            trailer: Trailer::default(),
+        }
+    }
 
-        builder.build()
+    pub fn from_bytes(config: &Config, dict: &Dictionary, data: &[u8]) -> ParsedMessage {
+        if let Ok(parser) = MessageParser::new(dict, config, data) {
+            parser.build()
+        } else {
+            ParsedMessage::UnexpectedError("Failed to create message parser".to_string())
+        }
     }
 
     pub fn encode(&mut self, config: &Config) -> EncodingResult<Vec<u8>> {

--- a/crates/hotfix-message/src/parsed_message.rs
+++ b/crates/hotfix-message/src/parsed_message.rs
@@ -1,0 +1,55 @@
+use crate::error::HeaderParsingError;
+use crate::message::Message;
+
+pub enum ParsedMessage {
+    Valid(Message),
+    Invalid {
+        message: Message,
+        reason: InvalidReason,
+    },
+    Garbled(GarbledReason),
+    UnexpectedError(String),
+}
+
+impl ParsedMessage {
+    pub fn into_message(self) -> Option<Message> {
+        match self {
+            ParsedMessage::Valid(message) => Some(message),
+            ParsedMessage::Invalid { message, .. } => Some(message),
+            _ => None,
+        }
+    }
+}
+
+pub enum InvalidReason {
+    InvalidField(u32),
+    InvalidGroup(u32),
+    InvalidComponent(String),
+}
+
+pub enum GarbledReason {
+    Malformed,
+    InvalidBeginString,
+    InvalidBodyLength,
+    InvalidMsgType,
+    InvalidChecksum,
+}
+
+impl From<HeaderParsingError> for ParsedMessage {
+    fn from(header_error: HeaderParsingError) -> Self {
+        match header_error {
+            HeaderParsingError::InvalidBeginString => {
+                ParsedMessage::Garbled(GarbledReason::InvalidBeginString)
+            }
+            HeaderParsingError::InvalidBodyLength => {
+                ParsedMessage::Garbled(GarbledReason::InvalidBodyLength)
+            }
+            HeaderParsingError::InvalidMsgType => {
+                ParsedMessage::Garbled(GarbledReason::InvalidMsgType)
+            }
+            HeaderParsingError::IncompleteMessage => {
+                ParsedMessage::Garbled(GarbledReason::Malformed)
+            }
+        }
+    }
+}

--- a/crates/hotfix-message/src/parsed_message.rs
+++ b/crates/hotfix-message/src/parsed_message.rs
@@ -1,4 +1,4 @@
-use crate::error::HeaderParsingError;
+use crate::error::MessageIntegrityError;
 use crate::message::Message;
 
 pub enum ParsedMessage {
@@ -27,6 +27,7 @@ pub enum InvalidReason {
     InvalidComponent(String),
 }
 
+#[derive(Debug)]
 pub enum GarbledReason {
     Malformed,
     InvalidBeginString,
@@ -35,20 +36,20 @@ pub enum GarbledReason {
     InvalidChecksum,
 }
 
-impl From<HeaderParsingError> for ParsedMessage {
-    fn from(header_error: HeaderParsingError) -> Self {
+impl From<MessageIntegrityError> for ParsedMessage {
+    fn from(header_error: MessageIntegrityError) -> Self {
         match header_error {
-            HeaderParsingError::InvalidBeginString => {
+            MessageIntegrityError::InvalidBeginString => {
                 ParsedMessage::Garbled(GarbledReason::InvalidBeginString)
             }
-            HeaderParsingError::InvalidBodyLength => {
+            MessageIntegrityError::InvalidBodyLength => {
                 ParsedMessage::Garbled(GarbledReason::InvalidBodyLength)
             }
-            HeaderParsingError::InvalidMsgType => {
+            MessageIntegrityError::InvalidMsgType => {
                 ParsedMessage::Garbled(GarbledReason::InvalidMsgType)
             }
-            HeaderParsingError::IncompleteMessage => {
-                ParsedMessage::Garbled(GarbledReason::Malformed)
+            MessageIntegrityError::InvalidCheckSum => {
+                ParsedMessage::Garbled(GarbledReason::InvalidChecksum)
             }
         }
     }

--- a/crates/hotfix-message/src/parser.rs
+++ b/crates/hotfix-message/src/parser.rs
@@ -1,8 +1,13 @@
 use crate::Part;
-use crate::error::{ParserError, ParserResult};
+use crate::error::{
+    HeaderParsingError, HeaderParsingResult, ParserError, ParserResult, TrailerParsingError,
+    TrailerParsingResult,
+};
 use crate::field_map::Field;
 use crate::message::{Config, Message};
+use crate::parsed_message::{GarbledReason, InvalidReason, ParsedMessage};
 use crate::parts::{Body, Header, RepeatingGroup, Trailer};
+use crate::tags::{BEGIN_STRING, BODY_LENGTH, CHECK_SUM, MSG_TYPE};
 use hotfix_dictionary::{Dictionary, LayoutItem, LayoutItemKind, TagU32};
 use std::collections::{HashMap, HashSet};
 
@@ -33,33 +38,110 @@ impl<'a> MessageParser<'a> {
         Ok(parser)
     }
 
-    pub(crate) fn build(&mut self) -> ParserResult<Message> {
-        let (header, next) = self.build_header()?;
-        let (body, next) = self.build_body(next)?;
-        let trailer = self.build_trailer(next);
+    pub(crate) fn build(mut self) -> ParsedMessage {
+        let (header, next) = match self.build_header() {
+            Ok((header, field)) => (header, field),
+            Err(err) => {
+                return err.into();
+            }
+        };
+
+        let (body, next) = match self.build_body(next) {
+            Ok((body, field)) => (body, field),
+            Err(err) => {
+                return match err {
+                    ParserError::IOError(_) => ParsedMessage::Garbled(GarbledReason::Malformed),
+                    ParserError::InvalidField(tag) => ParsedMessage::Invalid {
+                        reason: InvalidReason::InvalidField(tag),
+                        message: Message::with_header(header),
+                    },
+                    ParserError::InvalidGroup(tag) => ParsedMessage::Invalid {
+                        reason: InvalidReason::InvalidGroup(tag),
+                        message: Message::with_header(header),
+                    },
+                    ParserError::InvalidComponent(tag) => ParsedMessage::Invalid {
+                        reason: InvalidReason::InvalidComponent(tag),
+                        message: Message::with_header(header),
+                    },
+                    ParserError::Malformed(_) => ParsedMessage::Garbled(GarbledReason::Malformed),
+                };
+            }
+        };
+
+        let trailer = match self.build_trailer(next) {
+            Ok(trailer) => trailer,
+            Err(TrailerParsingError::InvalidField(tag)) => {
+                return ParsedMessage::Invalid {
+                    reason: InvalidReason::InvalidField(tag),
+                    message: Message::with_header(header),
+                };
+            }
+            Err(TrailerParsingError::InvalidCheckSum) => {
+                return ParsedMessage::Garbled(GarbledReason::InvalidChecksum);
+            }
+        };
 
         let msg = Message {
             header,
             body,
             trailer,
         };
-        Ok(msg)
+        if let Ok(body_length) = msg.header().get::<usize>(BODY_LENGTH) {
+            let calculated_length = msg.calculate_length();
+            if calculated_length != body_length {
+                return ParsedMessage::Garbled(GarbledReason::InvalidBodyLength);
+            }
+        } else {
+            return ParsedMessage::Garbled(GarbledReason::InvalidBodyLength);
+        }
+
+        ParsedMessage::Valid(msg)
     }
 
-    fn build_header(&mut self) -> ParserResult<(Header, Field)> {
-        // first three fields need to be BeginString (8), BodyLength (9), and MsgType(35)
+    fn build_header(&mut self) -> HeaderParsingResult<(Header, Field)> {
+        // the first three fields need to be BeginString (8), BodyLength (9), and MsgType(35)
         // https://www.onixs.biz/fix-dictionary/4.4/compblock_standardheader.html
+
         let mut header = Header::default();
 
-        loop {
-            let field = self.next_field().ok_or(ParserError::Malformed(
-                "message ended within header".to_string(),
-            ))?;
+        // parse BeginString
+        if let Some(begin_string) = self.next_field()
+            && begin_string.tag.get() == BEGIN_STRING.tag
+        {
+            header.fields.insert(begin_string);
+        } else {
+            return Err(HeaderParsingError::InvalidBeginString);
+        }
 
-            if self.header_tags.contains(&field.tag) {
-                header.fields.insert(field);
+        // parse BodyLength
+        if let Some(body_length) = self.next_field()
+            && body_length.tag.get() == BODY_LENGTH.tag
+        {
+            header.fields.insert(body_length);
+        } else {
+            return Err(HeaderParsingError::InvalidBodyLength);
+        }
+
+        // parse MsgType
+        if let Some(msg_type) = self.next_field()
+            && msg_type.tag.get() == MSG_TYPE.tag
+        {
+            header.fields.insert(msg_type);
+        } else {
+            return Err(HeaderParsingError::InvalidMsgType);
+        }
+
+        loop {
+            if let Some(field) = self.next_field() {
+                if self.header_tags.contains(&field.tag) {
+                    header.fields.insert(field);
+                } else {
+                    // the parsed field is valid, but no longer in the header, so we're ready to move on
+                    return Ok((header, field));
+                }
             } else {
-                return Ok((header, field));
+                // there is no next field, yet we're still in the header - something is very wrong
+                return Err(HeaderParsingError::IncompleteMessage);
             }
         }
     }
@@ -88,16 +170,31 @@ impl<'a> MessageParser<'a> {
         Ok((body, field))
     }
 
-    fn build_trailer(&mut self, next_field: Field) -> Trailer {
+    fn build_trailer(&mut self, next_field: Field) -> TrailerParsingResult<Trailer> {
         // https://www.onixs.biz/fix-dictionary/4.4/compblock_standardtrailer.html
         let mut trailer = Trailer::default();
-        let mut field = Some(next_field);
-        while let Some(f) = field {
-            trailer.store_field(f);
-            field = self.next_field();
+        let mut field = next_field;
+        loop {
+            if !self.trailer_tags.contains(&field.tag) {
+                return Err(TrailerParsingError::InvalidField(field.tag.get()));
+            }
+
+            let last_tag = field.tag.get();
+            trailer.store_field(field);
+
+            if let Some(next_field) = self.next_field() {
+                field = next_field;
+            } else {
+                // the very last tag needs to be the checksum
+                if last_tag != CHECK_SUM.tag {
+                    return Err(TrailerParsingError::InvalidCheckSum);
+                } else {
+                    break;
+                }
+            }
         }
 
-        trailer
+        Ok(trailer)
     }
 
     fn parse_groups(&mut self, start_tag: TagU32) -> ParserResult<(Vec<RepeatingGroup>, Field)> {
@@ -240,6 +337,7 @@ fn tag_from_bytes(bytes: &[u8]) -> Option<TagU32> {
 mod tests {
     use crate::field_types::Currency;
     use crate::message::{Config, Message};
+    use crate::parsed_message::ParsedMessage;
     use crate::{Part, fix44};
     use hotfix_dictionary::{Dictionary, IsFieldDefinition};
 
@@ -249,7 +347,9 @@ mod tests {
         let raw = b"8=FIX.4.4|9=40|35=D|49=AFUNDMGR|56=ABROKER|15=USD|59=0|10=091|";
         let dict = Dictionary::fix44();
 
-        let message = Message::from_bytes(&config, &dict, raw).unwrap();
+        let message = Message::from_bytes(&config, &dict, raw)
+            .into_message()
+            .unwrap();
 
         let begin: &str = message.header().get(fix44::BEGIN_STRING).unwrap();
         assert_eq!(begin, "FIX.4.4");
@@ -276,7 +376,9 @@ mod tests {
         let raw = b"8=FIX.4.4|9=219|35=8|49=SENDER|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=128|";
         let dict = Dictionary::fix44();
 
-        let message = Message::from_bytes(&config, &dict, raw).unwrap();
+        let message = Message::from_bytes(&config, &dict, raw)
+            .into_message()
+            .unwrap();
         let begin: &str = message.header().get(fix44::BEGIN_STRING).unwrap();
         assert_eq!(begin, "FIX.4.4");
 
@@ -298,7 +400,9 @@ mod tests {
         let raw = b"8=FIX.4.4|9=000|35=8|34=2|49=Broker|52=20231103-09:30:00|56=Client|11=Order12345|17=Exec12345|150=0|39=0|55=APPL|54=1|38=100|32=50|31=150.00|151=50|14=50|6=150.00|453=2|448=PARTYA|447=D|452=1|802=2|523=SUBPARTYA1|803=1|523=SUBPARTYA2|803=2|448=PARTYB|447=D|452=2|10=111|";
         let dict = Dictionary::fix44();
 
-        let message = Message::from_bytes(&config, &dict, raw).unwrap();
+        let message = Message::from_bytes(&config, &dict, raw)
+            .into_message()
+            .unwrap();
         let party_a = message.get_group(fix44::NO_PARTY_I_DS, 0).unwrap();
         let party_a_0 = party_a
             .get_group(fix44::NO_PARTY_SUB_I_DS.tag(), 0)

--- a/crates/hotfix-message/src/parser.rs
+++ b/crates/hotfix-message/src/parser.rs
@@ -373,7 +373,7 @@ fn parser_error_to_parsed_message(err: ParserError, header: Header) -> ParsedMes
 mod tests {
     use crate::field_types::Currency;
     use crate::message::{Config, Message};
-    use crate::parsed_message::{GarbledReason, ParsedMessage};
+    use crate::parsed_message::{GarbledReason, InvalidReason, ParsedMessage};
     use crate::{Part, fix44};
     use hotfix_dictionary::{Dictionary, IsFieldDefinition};
 
@@ -537,6 +537,21 @@ mod tests {
         assert!(matches!(
             parsed_message,
             ParsedMessage::Garbled(GarbledReason::InvalidChecksum)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_field_in_body() {
+        let raw = b"8=FIX.4.4|9=53|35=D|49=AFUNDMGR|9999=invalid|56=ABROKER|15=USD|59=0|10=229|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Invalid {
+                reason: InvalidReason::InvalidField(_),
+                ..
+            }
         ));
     }
 }

--- a/crates/hotfix-message/src/parser.rs
+++ b/crates/hotfix-message/src/parser.rs
@@ -1,9 +1,7 @@
 use crate::Part;
-use crate::error::{
-    HeaderParsingError, HeaderParsingResult, ParserError, ParserResult, TrailerParsingError,
-    TrailerParsingResult,
-};
+use crate::error::{MessageIntegrityError, ParserError, ParserResult};
 use crate::field_map::Field;
+use crate::field_types::CheckSum;
 use crate::message::{Config, Message};
 use crate::parsed_message::{GarbledReason, InvalidReason, ParsedMessage};
 use crate::parts::{Body, Header, RepeatingGroup, Trailer};
@@ -12,6 +10,17 @@ use hotfix_dictionary::{Dictionary, LayoutItem, LayoutItemKind, TagU32};
 use std::collections::{HashMap, HashSet};
 
 pub const SOH: u8 = 0x1;
+
+/// Length of the checksum field.
+///
+/// It should always be 7 bytes:
+/// - 2 bytes for the tag (`10`)
+/// - a byte for the separator
+/// - 3 bytes for the value
+/// - a byte for the final delimiter
+///
+/// e.g. `10=643|`
+const CHECKSUM_LENGTH: usize = 7;
 
 pub struct MessageParser<'a> {
     dict: &'a Dictionary,
@@ -39,109 +48,128 @@ impl<'a> MessageParser<'a> {
     }
 
     pub(crate) fn build(mut self) -> ParsedMessage {
-        let (header, next) = match self.build_header() {
-            Ok((header, field)) => (header, field),
+        let (mut header, mut trailer) = match self.verify_integrity() {
+            Ok((header, trailer)) => (header, trailer),
+            Err(err) => return err.into(),
+        };
+        let next = match self.build_header(&mut header) {
+            Ok(next_field) => next_field,
             Err(err) => {
-                return err.into();
+                return parser_error_to_parsed_message(err, header);
             }
         };
 
         let (body, next) = match self.build_body(next) {
             Ok((body, field)) => (body, field),
             Err(err) => {
-                return match err {
-                    ParserError::IOError(_) => ParsedMessage::Garbled(GarbledReason::Malformed),
-                    ParserError::InvalidField(tag) => ParsedMessage::Invalid {
-                        reason: InvalidReason::InvalidField(tag),
-                        message: Message::with_header(header),
-                    },
-                    ParserError::InvalidGroup(tag) => ParsedMessage::Invalid {
-                        reason: InvalidReason::InvalidGroup(tag),
-                        message: Message::with_header(header),
-                    },
-                    ParserError::InvalidComponent(tag) => ParsedMessage::Invalid {
-                        reason: InvalidReason::InvalidComponent(tag),
-                        message: Message::with_header(header),
-                    },
-                    ParserError::Malformed(_) => ParsedMessage::Garbled(GarbledReason::Malformed),
-                };
+                return parser_error_to_parsed_message(err, header);
             }
         };
 
-        let trailer = match self.build_trailer(next) {
-            Ok(trailer) => trailer,
-            Err(TrailerParsingError::InvalidField(tag)) => {
-                return ParsedMessage::Invalid {
-                    reason: InvalidReason::InvalidField(tag),
-                    message: Message::with_header(header),
-                };
-            }
-            Err(TrailerParsingError::InvalidCheckSum) => {
-                return ParsedMessage::Garbled(GarbledReason::InvalidChecksum);
-            }
-        };
+        self.build_trailer(&mut trailer, next);
 
         let msg = Message {
             header,
             body,
             trailer,
         };
-        if let Ok(body_length) = msg.header().get::<usize>(BODY_LENGTH) {
-            let calculated_length = msg.calculate_length();
-            if calculated_length != body_length {
-                return ParsedMessage::Garbled(GarbledReason::InvalidBodyLength);
-            }
-        } else {
-            return ParsedMessage::Garbled(GarbledReason::InvalidBodyLength);
-        }
-
         ParsedMessage::Valid(msg)
     }
 
-    fn build_header(&mut self) -> HeaderParsingResult<(Header, Field)> {
-        // the first three fields need to be BeginString (8), BodyLength (9), and MsgType(35)
-        // https://www.onixs.biz/fix-dictionary/4.4/compblock_standardheader.html
-
+    fn verify_integrity(&mut self) -> Result<(Header, Trailer), MessageIntegrityError> {
         let mut header = Header::default();
 
-        // parse BeginString
+        // The first field should always be BeginString
+        let begin_string_field = self.parse_begin_string()?;
+        header.fields.insert(begin_string_field);
+
+        // The second field should always be BodyLength
+        let body_length_field = self.parse_body_length()?;
+        header.fields.insert(body_length_field);
+
+        // The BodyLength is the number of bytes between the end of the BodyLength field and the start of the last field (i.e. the checksum)
+        let body_length = if let Ok(body_length) = header.get::<usize>(BODY_LENGTH) {
+            let expected_length = self.position + body_length + CHECKSUM_LENGTH;
+            if self.raw_data.len() != expected_length {
+                return Err(MessageIntegrityError::InvalidBodyLength);
+            }
+            body_length
+        } else {
+            // we failed to parse body length as usize
+            return Err(MessageIntegrityError::InvalidBodyLength);
+        };
+
+        // Parse the checksum (at the end of the message) and verify it matches the computed checksum
+        let mut trailer = Trailer::default();
+        let checksum_field = self.parse_checksum(self.position + body_length)?;
+        trailer.fields.insert(checksum_field);
+
+        if let Ok(checksum) = trailer.get::<CheckSum>(CHECK_SUM) {
+            let computed_checksum =
+                CheckSum::compute(&self.raw_data[0..self.position + body_length]);
+            if computed_checksum != checksum {
+                return Err(MessageIntegrityError::InvalidCheckSum);
+            }
+        }
+
+        // The third field should be the MsgType
+        let msg_type_field = self.parse_message_type()?;
+        header.fields.insert(msg_type_field);
+
+        Ok((header, trailer))
+    }
+
+    fn parse_begin_string(&mut self) -> Result<Field, MessageIntegrityError> {
         if let Some(begin_string) = self.next_field()
             && begin_string.tag.get() == BEGIN_STRING.tag
         {
-            header.fields.insert(begin_string);
+            Ok(begin_string)
         } else {
-            return Err(HeaderParsingError::InvalidBeginString);
+            Err(MessageIntegrityError::InvalidBeginString)
         }
+    }
 
-        // parse BodyLength
+    fn parse_body_length(&mut self) -> Result<Field, MessageIntegrityError> {
         if let Some(body_length) = self.next_field()
             && body_length.tag.get() == BODY_LENGTH.tag
         {
-            header.fields.insert(body_length);
+            Ok(body_length)
         } else {
-            return Err(HeaderParsingError::InvalidBodyLength);
+            Err(MessageIntegrityError::InvalidBodyLength)
         }
+    }
 
-        // parse MsgType
+    fn parse_message_type(&mut self) -> Result<Field, MessageIntegrityError> {
         if let Some(msg_type) = self.next_field()
             && msg_type.tag.get() == MSG_TYPE.tag
         {
-            header.fields.insert(msg_type);
+            Ok(msg_type)
         } else {
-            return Err(HeaderParsingError::InvalidMsgType);
+            Err(MessageIntegrityError::InvalidMsgType)
         }
+    }
 
+    fn parse_checksum(&self, checksum_start: usize) -> Result<Field, MessageIntegrityError> {
+        if let Some((checksum, _)) = self.parse_field_at(checksum_start)
+            && checksum.tag.get() == CHECK_SUM.tag
+        {
+            Ok(checksum)
+        } else {
+            Err(MessageIntegrityError::InvalidCheckSum)
+        }
+    }
+
+    fn build_header(&mut self, header: &mut Header) -> ParserResult<Field> {
+        // we have already added the first 3 mandatory fields, build the rest
         loop {
-            if let Some(field) = self.next_field() {
-                if self.header_tags.contains(&field.tag) {
-                    header.fields.insert(field);
-                } else {
-                    // the parsed field is valid, but no longer in the header, so we're ready to move on
-                    return Ok((header, field));
-                }
+            let field = self.next_field().ok_or(ParserError::Malformed(
+                "message ended within header".to_string(),
+            ))?;
+
+            if self.header_tags.contains(&field.tag) {
+                header.fields.insert(field);
             } else {
-                // there is no next field, yet we're still in the header - something is very wrong
-                return Err(HeaderParsingError::IncompleteMessage);
+                return Ok(field);
             }
         }
     }
@@ -170,31 +198,15 @@ impl<'a> MessageParser<'a> {
         Ok((body, field))
     }
 
-    fn build_trailer(&mut self, next_field: Field) -> TrailerParsingResult<Trailer> {
-        // https://www.onixs.biz/fix-dictionary/4.4/compblock_standardtrailer.html
-        let mut trailer = Trailer::default();
-        let mut field = next_field;
-        loop {
-            if !self.trailer_tags.contains(&field.tag) {
-                return Err(TrailerParsingError::InvalidField(field.tag.get()));
+    fn build_trailer(&mut self, trailer: &mut Trailer, next_field: Field) {
+        let mut field = Some(next_field);
+        while let Some(f) = field {
+            if f.tag.get() == CHECK_SUM.tag {
+                break;
             }
-
-            let last_tag = field.tag.get();
-            trailer.store_field(field);
-
-            if let Some(next_field) = self.next_field() {
-                field = next_field;
-            } else {
-                // the very last tag needs to be the checksum
-                if last_tag != CHECK_SUM.tag {
-                    return Err(TrailerParsingError::InvalidCheckSum);
-                } else {
-                    break;
-                }
-            }
+            trailer.store_field(f);
+            field = self.next_field();
         }
-
-        Ok(trailer)
     }
 
     fn parse_groups(&mut self, start_tag: TagU32) -> ParserResult<(Vec<RepeatingGroup>, Field)> {
@@ -251,18 +263,23 @@ impl<'a> MessageParser<'a> {
     }
 
     fn next_field(&mut self) -> Option<Field> {
-        let mut iter = self.raw_data[self.position..].iter();
-        let equal_sign_position = self.position + iter.position(|c| *c == b'=')?;
+        let (field, end_position) = self.parse_field_at(self.position)?;
+        self.position = end_position + 1;
+
+        Some(field)
+    }
+
+    fn parse_field_at(&self, position: usize) -> Option<(Field, usize)> {
+        let mut iter = self.raw_data[position..].iter();
+        let equal_sign_position = position + iter.position(|c| *c == b'=')?;
         let bytes_until_separator = iter.position(|c| *c == self.config.separator)?;
         let separator_position = equal_sign_position + bytes_until_separator + 1;
 
-        let tag = tag_from_bytes(&self.raw_data[self.position..equal_sign_position])?;
+        let tag = tag_from_bytes(&self.raw_data[position..equal_sign_position])?;
         let data = self.raw_data[equal_sign_position + 1..separator_position].to_vec();
         let field = Field::new(tag, data);
 
-        self.position = separator_position + 1;
-
-        Some(field)
+        Some((field, separator_position))
     }
 
     fn get_dict_field_by_tag(&self, tag: u32) -> ParserResult<hotfix_dictionary::Field> {
@@ -333,18 +350,36 @@ fn tag_from_bytes(bytes: &[u8]) -> Option<TagU32> {
     TagU32::new(tag)
 }
 
+fn parser_error_to_parsed_message(err: ParserError, header: Header) -> ParsedMessage {
+    match err {
+        ParserError::IOError(_) => ParsedMessage::Garbled(GarbledReason::Malformed),
+        ParserError::InvalidField(tag) => ParsedMessage::Invalid {
+            reason: InvalidReason::InvalidField(tag),
+            message: Message::with_header(header),
+        },
+        ParserError::InvalidGroup(tag) => ParsedMessage::Invalid {
+            reason: InvalidReason::InvalidGroup(tag),
+            message: Message::with_header(header),
+        },
+        ParserError::InvalidComponent(tag) => ParsedMessage::Invalid {
+            reason: InvalidReason::InvalidComponent(tag),
+            message: Message::with_header(header),
+        },
+        ParserError::Malformed(_) => ParsedMessage::Garbled(GarbledReason::Malformed),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::field_types::Currency;
     use crate::message::{Config, Message};
-    use crate::parsed_message::ParsedMessage;
     use crate::{Part, fix44};
     use hotfix_dictionary::{Dictionary, IsFieldDefinition};
 
     #[test]
     fn parse_simple_message() {
         let config = Config { separator: b'|' };
-        let raw = b"8=FIX.4.4|9=40|35=D|49=AFUNDMGR|56=ABROKER|15=USD|59=0|10=091|";
+        let raw = b"8=FIX.4.4|9=40|35=D|49=AFUNDMGR|56=ABROKER|15=USD|59=0|10=093|";
         let dict = Dictionary::fix44();
 
         let message = Message::from_bytes(&config, &dict, raw)
@@ -367,13 +402,13 @@ mod tests {
         assert_eq!(time_in_force, "0");
 
         let checksum: &str = message.trailer().get(fix44::CHECK_SUM).unwrap();
-        assert_eq!(checksum, "091");
+        assert_eq!(checksum, "093");
     }
 
     #[test]
     fn repeating_group_entries() {
         let config = Config { separator: b'|' };
-        let raw = b"8=FIX.4.4|9=219|35=8|49=SENDER|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=128|";
+        let raw = b"8=FIX.4.4|9=191|35=8|49=SENDER|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=140|";
         let dict = Dictionary::fix44();
 
         let message = Message::from_bytes(&config, &dict, raw)
@@ -391,13 +426,13 @@ mod tests {
         assert_eq!(fee_type, "7");
 
         let checksum: &str = message.trailer().get(fix44::CHECK_SUM).unwrap();
-        assert_eq!(checksum, "128");
+        assert_eq!(checksum, "140");
     }
 
     #[test]
     fn nested_repeating_group_entries() {
         let config = Config { separator: b'|' };
-        let raw = b"8=FIX.4.4|9=000|35=8|34=2|49=Broker|52=20231103-09:30:00|56=Client|11=Order12345|17=Exec12345|150=0|39=0|55=APPL|54=1|38=100|32=50|31=150.00|151=50|14=50|6=150.00|453=2|448=PARTYA|447=D|452=1|802=2|523=SUBPARTYA1|803=1|523=SUBPARTYA2|803=2|448=PARTYB|447=D|452=2|10=111|";
+        let raw = b"8=FIX.4.4|9=247|35=8|34=2|49=Broker|52=20231103-09:30:00|56=Client|11=Order12345|17=Exec12345|150=0|39=0|55=APPL|54=1|38=100|32=50|31=150.00|151=50|14=50|6=150.00|453=2|448=PARTYA|447=D|452=1|802=2|523=SUBPARTYA1|803=1|523=SUBPARTYA2|803=2|448=PARTYB|447=D|452=2|10=129|";
         let dict = Dictionary::fix44();
 
         let message = Message::from_bytes(&config, &dict, raw)
@@ -418,6 +453,6 @@ mod tests {
         assert_eq!(party_b_role, 2);
 
         let checksum: &str = message.trailer().get(fix44::CHECK_SUM).unwrap();
-        assert_eq!(checksum, "111");
+        assert_eq!(checksum, "129");
     }
 }

--- a/crates/hotfix-message/src/parser.rs
+++ b/crates/hotfix-message/src/parser.rs
@@ -554,4 +554,21 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn test_invalid_group_in_body() {
+        // tag=384 is `NoMsgTypes`, which is supposed to have `RefMsgType` (tag=372) and `MsgDirection` (tag=385)
+        // in our message, `RefMsgType` is missing
+        let raw = b"8=FIX.4.4|9=75|35=A|49=SENDER|56=TARGET|34=1|52=20231103-12:00:00|98=0|108=30|384=1|385=R|10=050|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Invalid {
+                reason: InvalidReason::InvalidGroup(_),
+                ..
+            }
+        ));
+    }
 }

--- a/crates/hotfix-message/src/parser.rs
+++ b/crates/hotfix-message/src/parser.rs
@@ -373,16 +373,18 @@ fn parser_error_to_parsed_message(err: ParserError, header: Header) -> ParsedMes
 mod tests {
     use crate::field_types::Currency;
     use crate::message::{Config, Message};
+    use crate::parsed_message::{GarbledReason, ParsedMessage};
     use crate::{Part, fix44};
     use hotfix_dictionary::{Dictionary, IsFieldDefinition};
 
+    const CONFIG: Config = Config { separator: b'|' };
+
     #[test]
     fn parse_simple_message() {
-        let config = Config { separator: b'|' };
         let raw = b"8=FIX.4.4|9=40|35=D|49=AFUNDMGR|56=ABROKER|15=USD|59=0|10=093|";
         let dict = Dictionary::fix44();
 
-        let message = Message::from_bytes(&config, &dict, raw)
+        let message = Message::from_bytes(&CONFIG, &dict, raw)
             .into_message()
             .unwrap();
 
@@ -407,11 +409,10 @@ mod tests {
 
     #[test]
     fn repeating_group_entries() {
-        let config = Config { separator: b'|' };
         let raw = b"8=FIX.4.4|9=191|35=8|49=SENDER|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=140|";
         let dict = Dictionary::fix44();
 
-        let message = Message::from_bytes(&config, &dict, raw)
+        let message = Message::from_bytes(&CONFIG, &dict, raw)
             .into_message()
             .unwrap();
         let begin: &str = message.header().get(fix44::BEGIN_STRING).unwrap();
@@ -431,11 +432,10 @@ mod tests {
 
     #[test]
     fn nested_repeating_group_entries() {
-        let config = Config { separator: b'|' };
         let raw = b"8=FIX.4.4|9=247|35=8|34=2|49=Broker|52=20231103-09:30:00|56=Client|11=Order12345|17=Exec12345|150=0|39=0|55=APPL|54=1|38=100|32=50|31=150.00|151=50|14=50|6=150.00|453=2|448=PARTYA|447=D|452=1|802=2|523=SUBPARTYA1|803=1|523=SUBPARTYA2|803=2|448=PARTYB|447=D|452=2|10=129|";
         let dict = Dictionary::fix44();
 
-        let message = Message::from_bytes(&config, &dict, raw)
+        let message = Message::from_bytes(&CONFIG, &dict, raw)
             .into_message()
             .unwrap();
         let party_a = message.get_group(fix44::NO_PARTY_I_DS, 0).unwrap();
@@ -454,5 +454,89 @@ mod tests {
 
         let checksum: &str = message.trailer().get(fix44::CHECK_SUM).unwrap();
         assert_eq!(checksum, "129");
+    }
+
+    #[test]
+    fn test_begin_string_not_the_first_tag() {
+        let raw = b"9=40|8=FIX.4.4|35=D|49=AFUNDMGR|56=ABROKER|15=USD|59=0|10=093|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Garbled(GarbledReason::InvalidBeginString)
+        ));
+    }
+
+    #[test]
+    fn test_body_length_not_the_second_tag() {
+        let raw = b"8=FIX.4.4|49=SENDER|9=191|35=8|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=140|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Garbled(GarbledReason::InvalidBodyLength)
+        ));
+    }
+
+    #[test]
+    fn test_body_length_is_wrong() {
+        let raw = b"8=FIX.4.4|9=192|35=8|49=SENDER|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=140|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Garbled(GarbledReason::InvalidBodyLength)
+        ));
+    }
+
+    #[test]
+    fn test_body_length_exceeds_message_length() {
+        let raw = b"8=FIX.4.4|9=500|35=8|49=SENDER|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=140|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Garbled(GarbledReason::InvalidBodyLength)
+        ));
+    }
+
+    #[test]
+    fn test_msg_type_is_not_the_third_tag() {
+        let raw = b"8=FIX.4.4|9=191|49=SENDER|35=8|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|139=7|10=140|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Garbled(GarbledReason::InvalidMsgType)
+        ));
+    }
+
+    #[test]
+    fn test_checksum_is_not_the_last_tag() {
+        let raw = b"8=FIX.4.4|9=191|35=8|49=SENDER|56=TARGET|34=123|52=20231103-12:00:00|11=12345|17=ABC123|150=2|39=1|55=XYZ|54=1|38=200|44=10|32=100|31=10|14=100|6=10|151=100|136=2|137=100|138=EUR|139=7|137=160|138=GBP|10=140|139=7|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Garbled(GarbledReason::InvalidChecksum)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_checksum() {
+        let raw = b"8=FIX.4.4|9=40|35=D|49=AFUNDMGR|56=ABROKER|15=USD|59=0|10=000|";
+        let dict = Dictionary::fix44();
+
+        let parsed_message = Message::from_bytes(&CONFIG, &dict, raw);
+        assert!(matches!(
+            parsed_message,
+            ParsedMessage::Garbled(GarbledReason::InvalidChecksum)
+        ));
     }
 }

--- a/crates/hotfix-message/src/tags.rs
+++ b/crates/hotfix-message/src/tags.rs
@@ -1,0 +1,30 @@
+use crate::HardCodedFixFieldDefinition;
+use hotfix_dictionary::{FieldLocation, FixDatatype};
+
+pub const BEGIN_STRING: &HardCodedFixFieldDefinition = &HardCodedFixFieldDefinition {
+    name: "BeginString",
+    tag: 8,
+    data_type: FixDatatype::String,
+    location: FieldLocation::Header,
+};
+
+pub const BODY_LENGTH: &HardCodedFixFieldDefinition = &HardCodedFixFieldDefinition {
+    name: "BodyLength",
+    tag: 9,
+    data_type: FixDatatype::Length,
+    location: FieldLocation::Header,
+};
+
+pub const MSG_TYPE: &HardCodedFixFieldDefinition = &HardCodedFixFieldDefinition {
+    name: "MsgType",
+    tag: 35,
+    data_type: FixDatatype::String,
+    location: FieldLocation::Header,
+};
+
+pub const CHECK_SUM: &HardCodedFixFieldDefinition = &HardCodedFixFieldDefinition {
+    name: "CheckSum",
+    tag: 10,
+    data_type: FixDatatype::String,
+    location: FieldLocation::Trailer,
+};

--- a/crates/hotfix/src/session.rs
+++ b/crates/hotfix/src/session.rs
@@ -34,6 +34,7 @@ use crate::session::event::AwaitingActiveSessionResponse;
 use crate::session::state::AwaitingResendState;
 use crate::session_schedule::SessionSchedule;
 use event::SessionEvent;
+use hotfix_message::parsed_message::ParsedMessage;
 use state::SessionState;
 
 const SCHEDULE_CHECK_INTERVAL: u64 = 1;
@@ -179,16 +180,19 @@ impl<M: FixMessage, S: MessageStore> Session<M, S> {
             &self.dictionary,
             raw_message.as_bytes(),
         ) {
-            Ok(message) => {
+            ParsedMessage::Valid(message) => {
                 self.process_message(message).await?;
                 self.check_end_of_resend().await?;
             }
-            Err(err) => {
+            ParsedMessage::Garbled(r) => {
                 // garbled messages should be skipped and we should assume it was a transmission error
                 let message = raw_message.to_string();
-                let error = err.to_string();
-                error!(message, error, "received garbled message");
+                let reason = format!("{r:?}");
+                error!(message, reason, "received garbled message");
                 // TODO: not all parsing errors indicate garbled messages
+            }
+            _ => {
+                error!("received invalid message, which are not handled yet");
             }
         }
 
@@ -491,6 +495,7 @@ impl<M: FixMessage, S: MessageStore> Session<M, S> {
             debug!(m, "resending message");
             let mut message =
                 Message::from_bytes(&self.message_config, &self.dictionary, msg.as_slice())
+                    .into_message()
                     .unwrap();
             sequence_number = message.header().get(fix44::MSG_SEQ_NUM).unwrap();
             let message_type: String = message


### PR DESCRIPTION
Implement message integrity checks, such as:
- BeginString being the first tag
- BodyLength being the second tag and having correct value
- MsgType being the third tag
- Checksum being the last tag and having correct value

It also improves the categorisation of parsing issues so we can handle them correctly in the session layer.