### PR TITLE
feat: handle infinite resend request loops

### DIFF
--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,7 +1,0 @@
-[all]
-workspace = true
-exclude = []
-exclude-files = [
-    "examples/**/*",
-    "tests/**/*"
-]

--- a/crates/hotfix/src/message.rs
+++ b/crates/hotfix/src/message.rs
@@ -27,7 +27,7 @@ pub trait FixMessage: Clone + Send + 'static {
 pub fn generate_message(
     sender_comp_id: &str,
     target_comp_id: &str,
-    msg_seq_num: usize,
+    msg_seq_num: u64,
     message: impl FixMessage,
 ) -> Result<Vec<u8>, EncodeError> {
     let mut msg = Message::new("FIX.4.4", message.message_type());

--- a/crates/hotfix/src/session.rs
+++ b/crates/hotfix/src/session.rs
@@ -680,7 +680,7 @@ impl<M: FixMessage, S: MessageStore> Session<M, S> {
         let msg = generate_message(
             &self.config.sender_comp_id,
             &self.config.target_comp_id,
-            seq_num as usize,
+            seq_num,
             message,
         )
         .unwrap();
@@ -703,7 +703,7 @@ impl<M: FixMessage, S: MessageStore> Session<M, S> {
         let raw_message = generate_message(
             &self.config.sender_comp_id,
             &self.config.target_comp_id,
-            begin as usize,
+            begin,
             sequence_reset,
         )
         .unwrap();

--- a/crates/hotfix/src/session.rs
+++ b/crates/hotfix/src/session.rs
@@ -32,7 +32,7 @@ use crate::message::sequence_reset::SequenceReset;
 use crate::message::test_request::TestRequest;
 use crate::message_utils::is_admin;
 use crate::session::event::AwaitingActiveSessionResponse;
-use crate::session::state::TestRequestId;
+use crate::session::state::{AwaitingResendTransitionOutcome, TestRequestId};
 use crate::session_schedule::SessionSchedule;
 use event::SessionEvent;
 use hotfix_message::fix44::SessionRejectReason;
@@ -576,9 +576,26 @@ impl<M: FixMessage, S: MessageStore> Session<M, S> {
     }
 
     async fn handle_sequence_number_too_high(&mut self, actual: u64, expected: u64) {
-        if self.state.try_transition_to_awaiting_resend(actual) {
-            debug!("we are behind target (ours: {expected}, theirs: {actual}), requesting resend.");
-            self.send_resend_request(expected, actual).await;
+        match self
+            .state
+            .try_transition_to_awaiting_resend(expected, actual)
+        {
+            AwaitingResendTransitionOutcome::Success => {
+                debug!(
+                    "we are behind target (ours: {expected}, theirs: {actual}), requesting resend."
+                );
+                self.send_resend_request(expected, actual).await;
+            }
+            AwaitingResendTransitionOutcome::InvalidState(reason) => {
+                error!("failed to request resend: {reason}");
+            }
+            AwaitingResendTransitionOutcome::AttemptsExceeded => {
+                self.state.disconnect().await;
+                self.state = SessionState::new_disconnected(
+                    false,
+                    "resend request attempts exceeded, manual intervention required",
+                );
+            }
         }
     }
 

--- a/crates/hotfix/src/session/info.rs
+++ b/crates/hotfix/src/session/info.rs
@@ -18,7 +18,11 @@ pub struct SessionInfo {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum Status {
     AwaitingLogon,
-    AwaitingResend,
+    AwaitingResend {
+        begin: u64,
+        end: u64,
+        attempts: usize,
+    },
     AwaitingLogout,
     Active,
     LoggedOut,

--- a/crates/hotfix/src/session/state.rs
+++ b/crates/hotfix/src/session/state.rs
@@ -10,6 +10,7 @@ use tokio::time::Instant;
 use tracing::{debug, error};
 
 const TEST_REQUEST_THRESHOLD: f64 = 1.2;
+const MAX_RESEND_ATTEMPTS: usize = 3;
 
 pub(crate) type TestRequestId = String;
 
@@ -136,19 +137,36 @@ impl SessionState {
         }
     }
 
-    pub fn try_transition_to_awaiting_resend(&mut self, end_seq_number: u64) -> bool {
-        if matches!(self, SessionState::AwaitingLogout { .. }) {
-            error!("trying to request a resend while we are already logging out");
-            return false;
-        }
-
-        if let Some(writer) = self.get_writer() {
-            let awaiting_resend = AwaitingResendState::new(writer.to_owned(), end_seq_number);
-            *self = SessionState::AwaitingResend(awaiting_resend);
-            true
-        } else {
-            error!("trying to transition to awaiting resend without an established connection");
-            false
+    pub fn try_transition_to_awaiting_resend(
+        &mut self,
+        begin: u64,
+        end: u64,
+    ) -> AwaitingResendTransitionOutcome {
+        match self {
+            SessionState::AwaitingLogon { writer, .. }
+            | SessionState::Active(ActiveState { writer, .. }) => {
+                let awaiting_resend = AwaitingResendState::new(writer.to_owned(), begin, end);
+                *self = SessionState::AwaitingResend(awaiting_resend);
+                AwaitingResendTransitionOutcome::Success
+            }
+            SessionState::AwaitingResend(state) => {
+                let new_state = AwaitingResendState::from_awaiting_resend(state, begin, end);
+                if new_state.has_exceeded_allowed_attempts() {
+                    AwaitingResendTransitionOutcome::AttemptsExceeded
+                } else {
+                    *self = SessionState::AwaitingResend(new_state);
+                    AwaitingResendTransitionOutcome::Success
+                }
+            }
+            SessionState::AwaitingLogout { .. } => AwaitingResendTransitionOutcome::InvalidState(
+                "trying to request a resend while we are already logging out".to_string(),
+            ),
+            SessionState::LoggedOut { .. } | SessionState::Disconnected(_) => {
+                AwaitingResendTransitionOutcome::InvalidState(
+                    "trying to transition to awaiting resend without an established connection"
+                        .to_string(),
+                )
+            }
         }
     }
 
@@ -285,19 +303,50 @@ pub struct ActiveState {
 pub struct AwaitingResendState {
     /// The reference to the writer loop.
     pub(crate) writer: WriterRef,
+    /// The beginning of the gap we're waiting for the target to resend.
+    pub(crate) begin_seq_number: u64,
     /// The end of the gap we're waiting for the target to resend.
     pub(crate) end_seq_number: u64,
     /// Inbound messages we receive while processing the resend.
     pub(crate) inbound_queue: VecDeque<Message>,
+    /// The number of times we've attempted to ask the counterparty to resend the gap.
+    pub(crate) resend_attempts: usize,
 }
 
 impl AwaitingResendState {
-    pub fn new(writer: WriterRef, end_seq_number: u64) -> Self {
+    fn new(writer: WriterRef, begin_seq_number: u64, end_seq_number: u64) -> Self {
         Self {
             writer,
+            begin_seq_number,
             end_seq_number,
             inbound_queue: Default::default(),
+            resend_attempts: 1,
         }
+    }
+
+    fn from_awaiting_resend(
+        state: &mut AwaitingResendState,
+        begin_seq_number: u64,
+        end_seq_number: u64,
+    ) -> Self {
+        let resend_attempts = if state.begin_seq_number == begin_seq_number {
+            state.resend_attempts + 1
+        } else {
+            1
+        };
+        let inbound_queue = std::mem::take(&mut state.inbound_queue);
+
+        Self {
+            writer: state.writer.clone(),
+            begin_seq_number,
+            end_seq_number,
+            inbound_queue,
+            resend_attempts,
+        }
+    }
+
+    fn has_exceeded_allowed_attempts(&self) -> bool {
+        self.resend_attempts >= MAX_RESEND_ATTEMPTS
     }
 }
 
@@ -327,4 +376,10 @@ impl DisconnectedState {
     fn take_session_awaiter(&mut self) -> Option<oneshot::Sender<AwaitingActiveSessionResponse>> {
         self.session_awaiter.take()
     }
+}
+
+pub enum AwaitingResendTransitionOutcome {
+    Success,
+    InvalidState(String),
+    AttemptsExceeded,
 }

--- a/crates/hotfix/src/session/state.rs
+++ b/crates/hotfix/src/session/state.rs
@@ -346,7 +346,7 @@ impl AwaitingResendState {
     }
 
     fn has_exceeded_allowed_attempts(&self) -> bool {
-        self.resend_attempts >= MAX_RESEND_ATTEMPTS
+        self.resend_attempts > MAX_RESEND_ATTEMPTS
     }
 }
 

--- a/crates/hotfix/src/session/state.rs
+++ b/crates/hotfix/src/session/state.rs
@@ -274,7 +274,16 @@ impl SessionState {
     pub fn as_status(&self) -> SessionInfoStatus {
         match self {
             SessionState::AwaitingLogon { .. } => SessionInfoStatus::AwaitingLogon,
-            SessionState::AwaitingResend(_) => SessionInfoStatus::AwaitingResend,
+            SessionState::AwaitingResend(AwaitingResendState {
+                begin_seq_number,
+                end_seq_number,
+                resend_attempts,
+                ..
+            }) => SessionInfoStatus::AwaitingResend {
+                begin: *begin_seq_number,
+                end: *end_seq_number,
+                attempts: *resend_attempts,
+            },
             SessionState::AwaitingLogout { .. } => SessionInfoStatus::AwaitingLogout,
             SessionState::Active(_) => SessionInfoStatus::Active,
             SessionState::LoggedOut { .. } => SessionInfoStatus::LoggedOut,

--- a/crates/hotfix/tests/common/mock_counterparty.rs
+++ b/crates/hotfix/tests/common/mock_counterparty.rs
@@ -53,7 +53,7 @@ where
         let raw_message = generate_message(
             &self.session_config.sender_comp_id,
             &self.session_config.target_comp_id,
-            self.sent_messages.len() + 1,
+            self.next_target_sequence_number(),
             message,
         )
         .expect("failed to generate message");
@@ -75,7 +75,7 @@ where
         let raw_message = generate_message(
             &self.session_config.sender_comp_id,
             &self.session_config.target_comp_id,
-            start_seq_no as usize,
+            start_seq_no,
             sequence_reset,
         )
         .expect("failed to generate message");
@@ -170,8 +170,8 @@ where
         }
     }
 
-    pub fn next_target_sequence_number(&self) -> usize {
-        self.sent_messages.len() + 1
+    pub fn next_target_sequence_number(&self) -> u64 {
+        self.sent_messages.len() as u64 + 1
     }
 
     fn create_writer() -> (WriterRef, Receiver<WriterMessage>) {

--- a/crates/hotfix/tests/common/test_messages.rs
+++ b/crates/hotfix/tests/common/test_messages.rs
@@ -214,7 +214,7 @@ pub const CUSTOM_FIELD: &HardCodedFixFieldDefinition = &HardCodedFixFieldDefinit
     location: FieldLocation::Body,
 };
 
-pub fn build_execution_report_with_incorrect_body_length(msg_seq_num: usize) -> Vec<u8> {
+pub fn build_execution_report_with_incorrect_body_length(msg_seq_num: u64) -> Vec<u8> {
     let report = TestMessage::dummy_execution_report();
     let mut raw_message =
         generate_message(COUNTERPARTY_COMP_ID, OUR_COMP_ID, msg_seq_num, report).unwrap();
@@ -224,7 +224,7 @@ pub fn build_execution_report_with_incorrect_body_length(msg_seq_num: usize) -> 
     raw_message
 }
 
-pub fn build_execution_report_with_incorrect_begin_string(msg_seq_num: usize) -> Vec<u8> {
+pub fn build_execution_report_with_incorrect_begin_string(msg_seq_num: u64) -> Vec<u8> {
     let report = TestMessage::dummy_execution_report();
 
     // we expect BeginString FIX.4.4 but this message contains FIX.4.2
@@ -240,7 +240,7 @@ pub fn build_execution_report_with_incorrect_begin_string(msg_seq_num: usize) ->
 }
 
 pub fn build_execution_report_with_comp_id(
-    msg_seq_num: usize,
+    msg_seq_num: u64,
     sender_comp_id: &str,
     target_comp_id: &str,
 ) -> Vec<u8> {

--- a/crates/hotfix/tests/common/test_messages.rs
+++ b/crates/hotfix/tests/common/test_messages.rs
@@ -1,6 +1,10 @@
+use crate::common::setup::{COUNTERPARTY_COMP_ID, OUR_COMP_ID};
 use hotfix::Message as HotfixMessage;
-use hotfix::message::FixMessage;
-use hotfix_message::{Part, fix44};
+use hotfix::message::{FixMessage, generate_message};
+use hotfix_message::dict::{FieldLocation, FixDatatype};
+use hotfix_message::field_types::Timestamp;
+use hotfix_message::message::{Config, Message};
+use hotfix_message::{HardCodedFixFieldDefinition, Part, fix44};
 
 /// Business messages used for testing.
 #[derive(Debug, Clone)]
@@ -146,6 +150,111 @@ impl FixMessage for TestMessage {
             _ => panic!("Invalid message type: {msg_type}"),
         }
     }
+}
+
+/// A new order message with an extra, invalid field.
+#[derive(Clone, Debug)]
+pub struct ExecutionReportWithInvalidField {
+    order_id: String,
+    exec_id: String,
+    exec_type: fix44::ExecType,
+    ord_status: fix44::OrdStatus,
+    side: fix44::Side,
+    symbol: String,
+    order_qty: f64,
+    price: f64,
+    custom_field: String, // this field isn't recognised by our session
+}
+
+impl Default for ExecutionReportWithInvalidField {
+    fn default() -> Self {
+        Self {
+            order_id: "ORD123".to_string(),
+            exec_id: "EX123".to_string(),
+            exec_type: fix44::ExecType::New,
+            ord_status: fix44::OrdStatus::New,
+            side: fix44::Side::Buy,
+            symbol: "".to_string(),
+            order_qty: 100.0,
+            price: 100.0,
+            custom_field: "Hello world".to_string(),
+        }
+    }
+}
+
+impl FixMessage for ExecutionReportWithInvalidField {
+    fn write(&self, msg: &mut Message) {
+        msg.set(fix44::ORDER_ID, self.order_id.as_str());
+        msg.set(fix44::EXEC_ID, self.exec_id.as_str());
+        msg.set(fix44::EXEC_TYPE, self.exec_type);
+        msg.set(fix44::ORD_STATUS, self.ord_status);
+        msg.set(fix44::SIDE, self.side);
+        msg.set(fix44::SYMBOL, self.symbol.as_str());
+        msg.set(fix44::ORDER_QTY, self.order_qty);
+        msg.set(fix44::PRICE, self.price);
+
+        // this is the important bit, we use a custom tag
+        msg.set(CUSTOM_FIELD, self.custom_field.as_str());
+    }
+
+    fn message_type(&self) -> &str {
+        "D"
+    }
+
+    fn parse(_message: &Message) -> Self {
+        // we never parse this message
+        unimplemented!()
+    }
+}
+
+pub const CUSTOM_FIELD: &HardCodedFixFieldDefinition = &HardCodedFixFieldDefinition {
+    name: "Custom Field",
+    tag: 9999,
+    data_type: FixDatatype::String,
+    location: FieldLocation::Body,
+};
+
+pub fn build_execution_report_with_incorrect_body_length(msg_seq_num: usize) -> Vec<u8> {
+    let report = TestMessage::dummy_execution_report();
+    let mut raw_message =
+        generate_message(COUNTERPARTY_COMP_ID, OUR_COMP_ID, msg_seq_num, report).unwrap();
+
+    replace_field_value(&mut raw_message, 9, b"999");
+
+    raw_message
+}
+
+pub fn build_execution_report_with_incorrect_begin_string(msg_seq_num: usize) -> Vec<u8> {
+    let report = TestMessage::dummy_execution_report();
+
+    // we expect BeginString FIX.4.4 but this message contains FIX.4.2
+    let mut msg = Message::new("FIX.4.2", report.message_type());
+    msg.set(fix44::SENDER_COMP_ID, COUNTERPARTY_COMP_ID);
+    msg.set(fix44::TARGET_COMP_ID, OUR_COMP_ID);
+    msg.set(fix44::MSG_SEQ_NUM, msg_seq_num);
+    msg.set(fix44::SENDING_TIME, Timestamp::utc_now());
+
+    report.write(&mut msg);
+
+    msg.encode(&Config::default()).unwrap()
+}
+
+pub fn build_execution_report_with_comp_id(
+    msg_seq_num: usize,
+    sender_comp_id: &str,
+    target_comp_id: &str,
+) -> Vec<u8> {
+    let report = TestMessage::dummy_execution_report();
+
+    let mut msg = Message::new("FIX.4.4", report.message_type());
+    msg.set(fix44::SENDER_COMP_ID, sender_comp_id);
+    msg.set(fix44::TARGET_COMP_ID, target_comp_id);
+    msg.set(fix44::MSG_SEQ_NUM, msg_seq_num);
+    msg.set(fix44::SENDING_TIME, Timestamp::utc_now());
+
+    report.write(&mut msg);
+
+    msg.encode(&Config::default()).unwrap()
 }
 
 /// Replaces the value of a field in a raw FIX message.

--- a/crates/hotfix/tests/session_test_cases/invalid_message_tests.rs
+++ b/crates/hotfix/tests/session_test_cases/invalid_message_tests.rs
@@ -1,14 +1,14 @@
 use crate::common::actions::when;
 use crate::common::assertions::then;
 use crate::common::setup::{COUNTERPARTY_COMP_ID, OUR_COMP_ID, given_an_active_session};
-use crate::common::test_messages::{TestMessage, replace_field_value};
-use hotfix::message::{FixMessage, generate_message};
+use crate::common::test_messages::{
+    ExecutionReportWithInvalidField, TestMessage, build_execution_report_with_comp_id,
+    build_execution_report_with_incorrect_begin_string,
+    build_execution_report_with_incorrect_body_length,
+};
 use hotfix::session::Status;
-use hotfix_message::dict::{FieldLocation, FixDatatype};
-use hotfix_message::field_types::Timestamp;
+use hotfix_message::Part;
 use hotfix_message::fix44::MSG_TYPE;
-use hotfix_message::message::{Config, Message};
-use hotfix_message::{HardCodedFixFieldDefinition, Part, fix44};
 
 /// Tests that when a counterparty sends a message containing an invalid/unrecognised field,
 /// the session rejects the message by sending a Reject (MsgType=3) message back.
@@ -129,109 +129,4 @@ async fn test_message_with_invalid_sender_comp_id() {
         .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "5"))
         .await;
     then(&mut mock_counterparty).gets_disconnected().await;
-}
-
-/// A new order message with an extra, invalid field.
-#[derive(Clone, Debug)]
-struct ExecutionReportWithInvalidField {
-    order_id: String,
-    exec_id: String,
-    exec_type: fix44::ExecType,
-    ord_status: fix44::OrdStatus,
-    side: fix44::Side,
-    symbol: String,
-    order_qty: f64,
-    price: f64,
-    custom_field: String, // this field isn't recognised by our session
-}
-
-impl Default for ExecutionReportWithInvalidField {
-    fn default() -> Self {
-        Self {
-            order_id: "ORD123".to_string(),
-            exec_id: "EX123".to_string(),
-            exec_type: fix44::ExecType::New,
-            ord_status: fix44::OrdStatus::New,
-            side: fix44::Side::Buy,
-            symbol: "".to_string(),
-            order_qty: 100.0,
-            price: 100.0,
-            custom_field: "Hello world".to_string(),
-        }
-    }
-}
-
-impl FixMessage for ExecutionReportWithInvalidField {
-    fn write(&self, msg: &mut Message) {
-        msg.set(fix44::ORDER_ID, self.order_id.as_str());
-        msg.set(fix44::EXEC_ID, self.exec_id.as_str());
-        msg.set(fix44::EXEC_TYPE, self.exec_type);
-        msg.set(fix44::ORD_STATUS, self.ord_status);
-        msg.set(fix44::SIDE, self.side);
-        msg.set(fix44::SYMBOL, self.symbol.as_str());
-        msg.set(fix44::ORDER_QTY, self.order_qty);
-        msg.set(fix44::PRICE, self.price);
-
-        // this is the important bit, we use a custom tag
-        msg.set(CUSTOM_FIELD, self.custom_field.as_str());
-    }
-
-    fn message_type(&self) -> &str {
-        "D"
-    }
-
-    fn parse(_message: &Message) -> Self {
-        // we never parse this message
-        unimplemented!()
-    }
-}
-
-pub const CUSTOM_FIELD: &HardCodedFixFieldDefinition = &HardCodedFixFieldDefinition {
-    name: "Custom Field",
-    tag: 9999,
-    data_type: FixDatatype::String,
-    location: FieldLocation::Body,
-};
-
-fn build_execution_report_with_incorrect_body_length(msg_seq_num: usize) -> Vec<u8> {
-    let report = TestMessage::dummy_execution_report();
-    let mut raw_message =
-        generate_message(COUNTERPARTY_COMP_ID, OUR_COMP_ID, msg_seq_num, report).unwrap();
-
-    replace_field_value(&mut raw_message, 9, b"999");
-
-    raw_message
-}
-
-fn build_execution_report_with_incorrect_begin_string(msg_seq_num: usize) -> Vec<u8> {
-    let report = TestMessage::dummy_execution_report();
-
-    // we expect BeginString FIX.4.4 but this message contains FIX.4.2
-    let mut msg = Message::new("FIX.4.2", report.message_type());
-    msg.set(fix44::SENDER_COMP_ID, COUNTERPARTY_COMP_ID);
-    msg.set(fix44::TARGET_COMP_ID, OUR_COMP_ID);
-    msg.set(fix44::MSG_SEQ_NUM, msg_seq_num);
-    msg.set(fix44::SENDING_TIME, Timestamp::utc_now());
-
-    report.write(&mut msg);
-
-    msg.encode(&Config::default()).unwrap()
-}
-
-fn build_execution_report_with_comp_id(
-    msg_seq_num: usize,
-    sender_comp_id: &str,
-    target_comp_id: &str,
-) -> Vec<u8> {
-    let report = TestMessage::dummy_execution_report();
-
-    let mut msg = Message::new("FIX.4.4", report.message_type());
-    msg.set(fix44::SENDER_COMP_ID, sender_comp_id);
-    msg.set(fix44::TARGET_COMP_ID, target_comp_id);
-    msg.set(fix44::MSG_SEQ_NUM, msg_seq_num);
-    msg.set(fix44::SENDING_TIME, Timestamp::utc_now());
-
-    report.write(&mut msg);
-
-    msg.encode(&Config::default()).unwrap()
 }

--- a/crates/hotfix/tests/session_test_cases/invalid_message_tests.rs
+++ b/crates/hotfix/tests/session_test_cases/invalid_message_tests.rs
@@ -34,9 +34,9 @@ async fn test_garbled_message_with_invalid_target_comp_id_gets_ignored() {
     let (session, mut mock_counterparty) = given_an_active_session().await;
 
     // counterparty sends a message with invalid body length, which constitutes a garbled message
-    let garbled_message = build_execution_report_with_incorrect_body_length(
-        mock_counterparty.next_target_sequence_number(),
-    );
+    let garbled_message_seq_num = mock_counterparty.next_target_sequence_number();
+    let garbled_message =
+        build_execution_report_with_incorrect_body_length(garbled_message_seq_num);
     when(&mut mock_counterparty)
         .sends_raw_message(garbled_message)
         .await;
@@ -51,7 +51,11 @@ async fn test_garbled_message_with_invalid_target_comp_id_gets_ignored() {
         .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "2"))
         .await;
     then(&session)
-        .status_changes_to(Status::AwaitingResend)
+        .status_changes_to(Status::AwaitingResend {
+            begin: garbled_message_seq_num as u64,
+            end: garbled_message_seq_num as u64 + 1,
+            attempts: 1,
+        })
         .await;
 
     when(&session).requests_disconnect().await;

--- a/crates/hotfix/tests/session_test_cases/invalid_message_tests.rs
+++ b/crates/hotfix/tests/session_test_cases/invalid_message_tests.rs
@@ -52,8 +52,8 @@ async fn test_garbled_message_with_invalid_target_comp_id_gets_ignored() {
         .await;
     then(&session)
         .status_changes_to(Status::AwaitingResend {
-            begin: garbled_message_seq_num as u64,
-            end: garbled_message_seq_num as u64 + 1,
+            begin: garbled_message_seq_num,
+            end: garbled_message_seq_num + 1,
             attempts: 1,
         })
         .await;

--- a/crates/hotfix/tests/session_test_cases/logon_tests.rs
+++ b/crates/hotfix/tests/session_test_cases/logon_tests.rs
@@ -116,7 +116,11 @@ async fn test_logon_response_with_sequence_number_too_high() {
     when(&mut mock_counterparty).sends_logon().await;
     // we then ask them to resend the message
     then(&session)
-        .status_changes_to(Status::AwaitingResend)
+        .status_changes_to(Status::AwaitingResend {
+            begin: 1,
+            end: 2,
+            attempts: 1,
+        })
         .await;
     then(&mut mock_counterparty)
         .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "2"))

--- a/crates/hotfix/tests/session_test_cases/resend_tests.rs
+++ b/crates/hotfix/tests/session_test_cases/resend_tests.rs
@@ -24,7 +24,11 @@ async fn test_message_sequence_number_too_high() {
 
     // we then ask them to resend the first message
     then(&session)
-        .status_changes_to(Status::AwaitingResend)
+        .status_changes_to(Status::AwaitingResend {
+            begin: 2,
+            end: 3,
+            attempts: 1,
+        })
         .await;
     then(&mut mock_counterparty)
         .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "2"))
@@ -61,16 +65,27 @@ async fn test_infinite_resend_requests_are_prevented() {
         .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "2"))
         .await;
     then(&session)
-        .status_changes_to(Status::AwaitingResend)
+        .status_changes_to(Status::AwaitingResend {
+            begin: garbled_message_seq_num as u64,
+            end: garbled_message_seq_num as u64 + 1,
+            attempts: 1,
+        })
         .await;
 
     // the counterparty attempts to resend twice more, but we are still unable to process the garbled message
-    for _ in 0..2 {
+    for attempts in 2..4 {
         when(&mut mock_counterparty)
             .resends_message(garbled_message_seq_num as u64)
             .await;
         when(&mut mock_counterparty)
             .resends_message(garbled_message_seq_num as u64 + 1)
+            .await;
+        then(&session)
+            .status_changes_to(Status::AwaitingResend {
+                begin: garbled_message_seq_num as u64,
+                end: garbled_message_seq_num as u64 + 1,
+                attempts,
+            })
             .await;
         then(&mut mock_counterparty)
             .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "2"))

--- a/crates/hotfix/tests/session_test_cases/resend_tests.rs
+++ b/crates/hotfix/tests/session_test_cases/resend_tests.rs
@@ -1,7 +1,9 @@
 use crate::common::actions::when;
 use crate::common::assertions::then;
 use crate::common::setup::given_an_active_session;
-use crate::common::test_messages::TestMessage;
+use crate::common::test_messages::{
+    TestMessage, build_execution_report_with_incorrect_body_length,
+};
 use hotfix::session::Status;
 use hotfix_message::Part;
 use hotfix_message::fix44::MSG_TYPE;
@@ -34,5 +36,53 @@ async fn test_message_sequence_number_too_high() {
     then(&session).status_changes_to(Status::Active).await;
 
     when(&session).requests_disconnect().await;
+    then(&mut mock_counterparty).gets_disconnected().await;
+}
+
+#[tokio::test]
+async fn test_infinite_resend_requests_are_prevented() {
+    let (session, mut mock_counterparty) = given_an_active_session().await;
+
+    // counterparty sends a message with invalid body length, which we skip as it's a garbled message
+    let garbled_message_seq_num = mock_counterparty.next_target_sequence_number();
+    let garbled_message =
+        build_execution_report_with_incorrect_body_length(garbled_message_seq_num);
+    when(&mut mock_counterparty)
+        .sends_raw_message(garbled_message)
+        .await;
+
+    // they then send a valid message
+    when(&mut mock_counterparty)
+        .sends_message(TestMessage::dummy_execution_report())
+        .await;
+
+    // we then initiate a resend, having skipped the garbled message
+    then(&mut mock_counterparty)
+        .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "2"))
+        .await;
+    then(&session)
+        .status_changes_to(Status::AwaitingResend)
+        .await;
+
+    // the counterparty attempts to resend twice more, but we are still unable to process the garbled message
+    for _ in 0..2 {
+        when(&mut mock_counterparty)
+            .resends_message(garbled_message_seq_num as u64)
+            .await;
+        when(&mut mock_counterparty)
+            .resends_message(garbled_message_seq_num as u64 + 1)
+            .await;
+        then(&mut mock_counterparty)
+            .receives(|msg| assert_eq!(msg.header().get::<&str>(MSG_TYPE).unwrap(), "2"))
+            .await;
+    }
+
+    // they try a third time, which exceeds are attempts threshold, so the connection is terminated
+    when(&mut mock_counterparty)
+        .resends_message(garbled_message_seq_num as u64)
+        .await;
+    when(&mut mock_counterparty)
+        .resends_message(garbled_message_seq_num as u64 + 1)
+        .await;
     then(&mut mock_counterparty).gets_disconnected().await;
 }

--- a/crates/hotfix/tests/session_test_cases/resend_tests.rs
+++ b/crates/hotfix/tests/session_test_cases/resend_tests.rs
@@ -43,6 +43,8 @@ async fn test_message_sequence_number_too_high() {
     then(&mut mock_counterparty).gets_disconnected().await;
 }
 
+/// Tests that when a counterparty repeatedly resends garbled messages that cannot be processed,
+/// the session eventually terminates the connection after exceeding the maximum resend attempts threshold.
 #[tokio::test]
 async fn test_infinite_resend_requests_are_prevented() {
     let (session, mut mock_counterparty) = given_an_active_session().await;
@@ -66,8 +68,8 @@ async fn test_infinite_resend_requests_are_prevented() {
         .await;
     then(&session)
         .status_changes_to(Status::AwaitingResend {
-            begin: garbled_message_seq_num as u64,
-            end: garbled_message_seq_num as u64 + 1,
+            begin: garbled_message_seq_num,
+            end: garbled_message_seq_num + 1,
             attempts: 1,
         })
         .await;
@@ -75,15 +77,15 @@ async fn test_infinite_resend_requests_are_prevented() {
     // the counterparty attempts to resend twice more, but we are still unable to process the garbled message
     for attempts in 2..4 {
         when(&mut mock_counterparty)
-            .resends_message(garbled_message_seq_num as u64)
+            .resends_message(garbled_message_seq_num)
             .await;
         when(&mut mock_counterparty)
-            .resends_message(garbled_message_seq_num as u64 + 1)
+            .resends_message(garbled_message_seq_num + 1)
             .await;
         then(&session)
             .status_changes_to(Status::AwaitingResend {
-                begin: garbled_message_seq_num as u64,
-                end: garbled_message_seq_num as u64 + 1,
+                begin: garbled_message_seq_num,
+                end: garbled_message_seq_num + 1,
                 attempts,
             })
             .await;
@@ -94,10 +96,10 @@ async fn test_infinite_resend_requests_are_prevented() {
 
     // they try a third time, which exceeds are attempts threshold, so the connection is terminated
     when(&mut mock_counterparty)
-        .resends_message(garbled_message_seq_num as u64)
+        .resends_message(garbled_message_seq_num)
         .await;
     when(&mut mock_counterparty)
-        .resends_message(garbled_message_seq_num as u64 + 1)
+        .resends_message(garbled_message_seq_num + 1)
         .await;
     then(&mut mock_counterparty).gets_disconnected().await;
 }


### PR DESCRIPTION
Protect against the scenario where we'd get into an infinite resend request loop due to the counterparty sending a garbled message.