### PR TITLE
feat: make smartstrings a feature for hotfix-dictionary

### DIFF
--- a/crates/hotfix-dictionary/Cargo.toml
+++ b/crates/hotfix-dictionary/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
+default = ["smartstring"]
 fix40 = []
 fix41 = []
 fix42 = []
@@ -21,6 +22,7 @@ fix50 = []
 fix50sp1 = []
 fix50sp2 = []
 fixt11 = []
+smartstring = ["dep:smartstring"]
 
 [lints]
 workspace = true
@@ -28,6 +30,6 @@ workspace = true
 [dependencies]
 fnv.workspace = true
 roxmltree.workspace = true
-smartstring.workspace = true
+smartstring = { workspace = true, optional = true }
 strum.workspace = true
 strum_macros.workspace = true

--- a/crates/hotfix-dictionary/src/component.rs
+++ b/crates/hotfix-dictionary/src/component.rs
@@ -1,5 +1,4 @@
-use smartstring::alias::String as SmartString;
-
+use crate::string::SmartString;
 use crate::{Dictionary, Field, LayoutItem, LayoutItemData, LayoutItemKind};
 
 /// A [`Component`] is an ordered collection of fields and/or other components.

--- a/crates/hotfix-dictionary/src/dictionary.rs
+++ b/crates/hotfix-dictionary/src/dictionary.rs
@@ -2,8 +2,8 @@ use crate::{Component, ComponentData, Datatype, DatatypeData, Field, FieldData};
 
 use crate::message_definition::{MessageData, MessageDefinition};
 use crate::quickfix::{ParseDictionaryError, QuickFixReader};
+use crate::string::SmartString;
 use fnv::FnvHashMap;
-use smartstring::alias::String as SmartString;
 
 /// Specifies business semantics for application-level entities within the FIX
 /// Protocol.

--- a/crates/hotfix-dictionary/src/field.rs
+++ b/crates/hotfix-dictionary/src/field.rs
@@ -1,5 +1,5 @@
+use crate::string::SmartString;
 use crate::{Datatype, Dictionary, FixDatatype, TagU32};
-use smartstring::alias::String as SmartString;
 
 pub trait IsFieldDefinition {
     /// Returns the FIX tag associated with `self`.

--- a/crates/hotfix-dictionary/src/layout.rs
+++ b/crates/hotfix-dictionary/src/layout.rs
@@ -1,7 +1,7 @@
-use smartstring::alias::String as SmartString;
 use std::fmt;
 
 use crate::component::Component;
+use crate::string::SmartString;
 use crate::{Dictionary, Field};
 
 pub fn display_layout_item(indent: u32, item: LayoutItem, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/hotfix-dictionary/src/lib.rs
+++ b/crates/hotfix-dictionary/src/lib.rs
@@ -8,6 +8,7 @@ mod field;
 mod layout;
 mod message_definition;
 mod quickfix;
+mod string;
 
 use component::{Component, ComponentData};
 use datatype::DatatypeData;

--- a/crates/hotfix-dictionary/src/message_definition.rs
+++ b/crates/hotfix-dictionary/src/message_definition.rs
@@ -1,5 +1,5 @@
+use crate::string::SmartString;
 use crate::{Dictionary, LayoutItem, LayoutItems};
-use smartstring::alias::String as SmartString;
 
 #[derive(Clone, Debug)]
 pub struct MessageData {

--- a/crates/hotfix-dictionary/src/quickfix.rs
+++ b/crates/hotfix-dictionary/src/quickfix.rs
@@ -1,8 +1,7 @@
-use smartstring::alias::String as SmartString;
-
 use crate::builder::DictionaryBuilder;
 use crate::component::{ComponentData, FixmlComponentAttributes};
 use crate::message_definition::MessageData;
+use crate::string::SmartString;
 use crate::{
     DatatypeData, Dictionary, FieldData, FieldEnumData, FixDatatype, LayoutItemData,
     LayoutItemKindData, LayoutItems,

--- a/crates/hotfix-dictionary/src/string.rs
+++ b/crates/hotfix-dictionary/src/string.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "smartstring")]
+pub(crate) use smartstring::alias::String as SmartString;
+#[cfg(not(feature = "smartstring"))]
+pub(crate) use std::string::String as SmartString;


### PR DESCRIPTION
This makes smartstrings a feature that's enabled by default in the `hotfix-dictionary` crate. When it isn't enabled, it falls back to using standard strings.

A benefit of this is debugging, as smartstrings are much harder to read in the debugger.